### PR TITLE
More failsafes when osu! apis stop working

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - cheesegull-mirror-fallback
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - cheesegull-mirror-fallback
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/app/adapters/osu_mirrors/__init__.py
+++ b/app/adapters/osu_mirrors/__init__.py
@@ -10,7 +10,8 @@ from app.adapters.osu_mirrors.backends.osu_direct import OsuDirectMirror
 from app.adapters.osu_mirrors.selectors.dynamic_round_robin import (
     DynamicWeightedRoundRobinMirrorSelector,
 )
-from app.common_models import CheesegullBeatmap, CheesegullBeatmapset
+from app.common_models import CheesegullBeatmap
+from app.common_models import CheesegullBeatmapset
 from app.repositories import beatmap_mirror_requests
 from app.repositories.beatmap_mirror_requests import MirrorResource
 

--- a/app/adapters/osu_mirrors/backends/__init__.py
+++ b/app/adapters/osu_mirrors/backends/__init__.py
@@ -7,7 +7,8 @@ from typing import TypeVar
 
 import httpx
 
-from app.common_models import CheesegullBeatmap, CheesegullBeatmapset
+from app.common_models import CheesegullBeatmap
+from app.common_models import CheesegullBeatmapset
 from app.repositories.beatmap_mirror_requests import MirrorResource
 
 T = TypeVar("T", covariant=True)

--- a/app/adapters/osu_mirrors/backends/__init__.py
+++ b/app/adapters/osu_mirrors/backends/__init__.py
@@ -7,6 +7,7 @@ from typing import TypeVar
 
 import httpx
 
+from app.common_models import CheesegullBeatmap, CheesegullBeatmapset
 from app.repositories.beatmap_mirror_requests import MirrorResource
 
 T = TypeVar("T", covariant=True)
@@ -32,6 +33,20 @@ class AbstractBeatmapMirror(ABC):
         )
         self.weight = 0
         super().__init__(*args, **kwargs)
+
+    async def fetch_one_cheesegull_beatmap(
+        self,
+        beatmap_id: int,
+    ) -> BeatmapMirrorResponse[CheesegullBeatmap | None]:
+        """Fetch a cheesegull beatmap from a beatmap mirror."""
+        raise NotImplementedError()
+
+    async def fetch_one_cheesegull_beatmapset(
+        self,
+        beatmapset_id: int,
+    ) -> BeatmapMirrorResponse[CheesegullBeatmapset | None]:
+        """Fetch a cheesegull beatmapset from a beatmap mirror."""
+        raise NotImplementedError
 
     async def fetch_beatmap_zip_data(
         self,

--- a/app/adapters/osu_mirrors/backends/__init__.py
+++ b/app/adapters/osu_mirrors/backends/__init__.py
@@ -47,7 +47,7 @@ class AbstractBeatmapMirror(ABC):
         beatmapset_id: int,
     ) -> BeatmapMirrorResponse[CheesegullBeatmapset | None]:
         """Fetch a cheesegull beatmapset from a beatmap mirror."""
-        raise NotImplementedError
+        raise NotImplementedError()
 
     async def fetch_beatmap_zip_data(
         self,

--- a/app/adapters/osu_mirrors/backends/osu_direct.py
+++ b/app/adapters/osu_mirrors/backends/osu_direct.py
@@ -32,7 +32,7 @@ class OsuDirectMirror(AbstractBeatmapMirror):
                 )
             response.raise_for_status()
             return BeatmapMirrorResponse(
-                data=response.json(),
+                data=CheesegullBeatmap.model_validate(response.json()),
                 is_success=True,
                 request_url=str(response.request.url),
                 status_code=response.status_code,
@@ -65,7 +65,7 @@ class OsuDirectMirror(AbstractBeatmapMirror):
                 )
             response.raise_for_status()
             return BeatmapMirrorResponse(
-                data=response.json(),
+                data=CheesegullBeatmapset.model_validate(response.json()),
                 is_success=True,
                 request_url=str(response.request.url),
                 status_code=response.status_code,

--- a/app/adapters/osu_mirrors/backends/osu_direct.py
+++ b/app/adapters/osu_mirrors/backends/osu_direct.py
@@ -5,7 +5,8 @@ from typing_extensions import override
 
 from app.adapters.osu_mirrors.backends import AbstractBeatmapMirror
 from app.adapters.osu_mirrors.backends import BeatmapMirrorResponse
-from app.common_models import CheesegullBeatmap, CheesegullBeatmapset
+from app.common_models import CheesegullBeatmap
+from app.common_models import CheesegullBeatmapset
 from app.repositories.beatmap_mirror_requests import MirrorResource
 
 

--- a/app/adapters/osu_mirrors/backends/osu_direct.py
+++ b/app/adapters/osu_mirrors/backends/osu_direct.py
@@ -5,6 +5,7 @@ from typing_extensions import override
 
 from app.adapters.osu_mirrors.backends import AbstractBeatmapMirror
 from app.adapters.osu_mirrors.backends import BeatmapMirrorResponse
+from app.common_models import CheesegullBeatmap, CheesegullBeatmapset
 from app.repositories.beatmap_mirror_requests import MirrorResource
 
 
@@ -12,6 +13,72 @@ class OsuDirectMirror(AbstractBeatmapMirror):
     name = "osu_direct"
     base_url = "https://osu.direct"
     supported_resources = {MirrorResource.OSZ_FILE, MirrorResource.BACKGROUND_IMAGE}
+
+    @override
+    async def fetch_one_cheesegull_beatmap(
+        self,
+        beatmap_id: int,
+    ) -> BeatmapMirrorResponse[CheesegullBeatmap | None]:
+        response: httpx.Response | None = None
+        try:
+            response = await self.http_client.get(
+                f"{self.base_url}/api/b/{beatmap_id}",
+            )
+            if response.status_code in (404, 451):
+                return BeatmapMirrorResponse(
+                    data=None,
+                    is_success=True,
+                    request_url=str(response.request.url),
+                    status_code=response.status_code,
+                )
+            response.raise_for_status()
+            return BeatmapMirrorResponse(
+                data=response.json(),
+                is_success=True,
+                request_url=str(response.request.url),
+                status_code=response.status_code,
+            )
+        except Exception as exc:
+            return BeatmapMirrorResponse(
+                data=None,
+                is_success=False,
+                request_url=str(response.request.url) if response else None,
+                status_code=response.status_code if response else None,
+                error_message=str(exc),
+            )
+
+    @override
+    async def fetch_one_cheesegull_beatmapset(
+        self,
+        beatmapset_id: int,
+    ) -> BeatmapMirrorResponse[CheesegullBeatmapset | None]:
+        response: httpx.Response | None = None
+        try:
+            response = await self.http_client.get(
+                f"{self.base_url}/api/s/{beatmapset_id}",
+            )
+            if response.status_code in (404, 451):
+                return BeatmapMirrorResponse(
+                    data=None,
+                    is_success=True,
+                    request_url=str(response.request.url),
+                    status_code=response.status_code,
+                )
+            response.raise_for_status()
+            return BeatmapMirrorResponse(
+                data=response.json(),
+                is_success=True,
+                request_url=str(response.request.url),
+                status_code=response.status_code,
+            )
+        except Exception as exc:
+            return BeatmapMirrorResponse(
+                data=None,
+                is_success=False,
+                request_url=str(response.request.url) if response else None,
+                status_code=response.status_code if response else None,
+                error_message=str(exc),
+            )
 
     @override
     async def fetch_beatmap_zip_data(

--- a/app/adapters/osu_mirrors/backends/osu_direct.py
+++ b/app/adapters/osu_mirrors/backends/osu_direct.py
@@ -1,5 +1,3 @@
-import logging
-
 import httpx
 from typing_extensions import override
 

--- a/app/api/public/cheesegull.py
+++ b/app/api/public/cheesegull.py
@@ -4,120 +4,15 @@ Provides an API aligned with the Cheesegull API Specification.
 API Spec: https://docs.ripple.moe/docs/cheesegull/cheesegull-api
 """
 
-import logging
-from datetime import datetime
-from enum import IntEnum
-
 from fastapi import APIRouter
 from fastapi import Header
 from fastapi import Query
 from fastapi import Response
-from pydantic import BaseModel
-
-from app.adapters.osu_api_v2 import api as osu_api_v2
-from app.adapters.osu_api_v2.models import BeatmapExtended
-from app.adapters.osu_api_v2.models import BeatmapsetExtended
-from app.adapters.osu_api_v2.models import Category
 from app.api.responses import JSONResponse
-from app.common_models import GameMode
-from app.common_models import RankedStatus
+from app.common_models import CheesegullRankedStatus, GameMode
+from app.usecases import cheesegull_beatmaps
 
 router = APIRouter(tags=["(Public) Cheesegull API"])
-
-
-class CheesegullBeatmap(BaseModel):
-    BeatmapID: int
-    ParentSetID: int
-    DiffName: str
-    FileMD5: str
-    Mode: int
-    BPM: float
-    AR: float
-    OD: float
-    CS: float
-    HP: float
-    TotalLength: int
-    HitLength: int
-    Playcount: int
-    Passcount: int
-    MaxCombo: int
-    DifficultyRating: float
-
-    @classmethod
-    def from_osu_api_beatmap(
-        cls,
-        beatmap: BeatmapExtended,
-    ) -> "CheesegullBeatmap":
-        return cls(
-            BeatmapID=beatmap.id,
-            ParentSetID=beatmap.beatmapset_id,
-            DiffName=beatmap.version,
-            FileMD5=beatmap.checksum or "",
-            Mode=beatmap.mode_int,
-            BPM=beatmap.bpm or 0,
-            AR=beatmap.ar,
-            OD=beatmap.accuracy,
-            CS=beatmap.cs,
-            HP=beatmap.drain,
-            TotalLength=beatmap.total_length,
-            HitLength=beatmap.total_length,
-            Playcount=beatmap.playcount,
-            Passcount=beatmap.passcount,
-            MaxCombo=beatmap.max_combo or 0,
-            DifficultyRating=beatmap.difficulty_rating,
-        )
-
-
-class CheesegullBeatmapset(BaseModel):
-    SetID: int
-    ChildrenBeatmaps: list[CheesegullBeatmap]
-    RankedStatus: int
-    ApprovedDate: datetime
-    LastUpdate: datetime
-    LastChecked: datetime
-    Artist: str
-    Title: str
-    Creator: str
-    Source: str
-    Tags: str
-    HasVideo: bool
-    Genre: int | None
-    Language: int | None
-    Favourites: int
-
-    @classmethod
-    def from_osu_api_beatmapset(
-        cls,
-        osu_api_beatmapset: BeatmapsetExtended,
-    ) -> "CheesegullBeatmapset":
-        children_beatmaps: list[CheesegullBeatmap] = []
-        for osu_api_beatmap in osu_api_beatmapset.beatmaps or []:
-            if not isinstance(osu_api_beatmap, BeatmapExtended):
-                raise ValueError("beatmapset.beatmaps is not a list of BeatmapExtended")
-            cheesegull_beatmap = CheesegullBeatmap.from_osu_api_beatmap(osu_api_beatmap)
-            children_beatmaps.append(cheesegull_beatmap)
-
-        return cls(
-            SetID=osu_api_beatmapset.id,
-            ChildrenBeatmaps=children_beatmaps,
-            RankedStatus=osu_api_beatmapset.ranked,
-            ApprovedDate=osu_api_beatmapset.ranked_date or datetime.min,
-            LastUpdate=(
-                osu_api_beatmapset.ranked_date or osu_api_beatmapset.last_updated
-            ),
-            LastChecked=datetime.now(),  # TODO: Implement this
-            Artist=osu_api_beatmapset.artist,
-            Title=osu_api_beatmapset.title,
-            Creator=osu_api_beatmapset.creator,
-            Source=osu_api_beatmapset.source,
-            Tags=osu_api_beatmapset.tags,
-            HasVideo=osu_api_beatmapset.video,
-            Genre=osu_api_beatmapset.genre.id if osu_api_beatmapset.genre else None,
-            Language=(
-                osu_api_beatmapset.language.id if osu_api_beatmapset.language else None
-            ),
-            Favourites=osu_api_beatmapset.favourite_count,
-        )
 
 
 @router.get("/public/api/b/{beatmap_id}")
@@ -126,20 +21,15 @@ async def cheesegull_beatmap(
     client_ip_address: str | None = Header(None, alias="X-Real-IP"),
     client_user_agent: str | None = Header(None, alias="User-Agent"),
 ) -> Response:
-    osu_api_beatmap = await osu_api_v2.get_beatmap(beatmap_id)
-    if osu_api_beatmap is None:
+    response = await cheesegull_beatmaps.fetch_one_cheesegull_beatmap(
+        beatmap_id,
+        client_ip_address=client_ip_address,
+        client_user_agent=client_user_agent,
+    )
+    if response is None:
         return Response(status_code=404)
 
-    cheesegull_beatmap = CheesegullBeatmap.from_osu_api_beatmap(osu_api_beatmap)
-    logging.debug(
-        "Serving cheesegull beatmap",
-        extra={
-            "beatmap_id": beatmap_id,
-            "client_ip_address": client_ip_address,
-            "client_user_agent": client_user_agent,
-        },
-    )
-    return JSONResponse(content=cheesegull_beatmap.model_dump())
+    return JSONResponse(content=response.model_dump())
 
 
 @router.get("/public/api/s/{beatmapset_id}")
@@ -148,39 +38,15 @@ async def cheesegull_beatmapset(
     client_ip_address: str | None = Header(None, alias="X-Real-IP"),
     client_user_agent: str | None = Header(None, alias="User-Agent"),
 ) -> Response:
-    osu_api_beatmapset = await osu_api_v2.get_beatmapset(beatmapset_id)
-    if osu_api_beatmapset is None:
+    response = await cheesegull_beatmaps.fetch_one_cheesegull_beatmapset(
+        beatmapset_id,
+        client_ip_address=client_ip_address,
+        client_user_agent=client_user_agent,
+    )
+    if response is None:
         return Response(status_code=404)
 
-    cheesegull_beatmapset = CheesegullBeatmapset.from_osu_api_beatmapset(
-        osu_api_beatmapset,
-    )
-    logging.debug(
-        "Serving cheesegull beatmapset",
-        extra={
-            "beatmapset_id": beatmapset_id,
-            "client_ip_address": client_ip_address,
-            "client_user_agent": client_user_agent,
-        },
-    )
-    return JSONResponse(content=cheesegull_beatmapset.model_dump())
-
-
-class CheesegullRankedStatus(IntEnum):
-    # This is a limited subset of the osu! api ranked status
-    PENDING = 0
-    RANKED = 1
-    APPROVED = 2
-    QUALIFIED = 3
-    LOVED = 4
-
-
-def get_osu_api_v2_search_ranked_status(
-    cheesegull_status: CheesegullRankedStatus,
-) -> Category | None:
-    ranked_status = RankedStatus.from_osu_api(cheesegull_status)
-    search_ranked_status = Category.from_ranked_status(ranked_status)
-    return search_ranked_status
+    return JSONResponse(content=response.model_dump())
 
 
 @router.get("/public/api/search")
@@ -194,44 +60,16 @@ async def cheesegull_search(
     client_user_agent: str | None = Header(None, alias="User-Agent"),
     # TODO: auth, or at least per-ip ratelimit
 ) -> Response:
-    if status is not None:
-        ranked_status = get_osu_api_v2_search_ranked_status(status)
-        if ranked_status is None:
-            return Response(status_code=400)
-    else:
-        ranked_status = None
-
-    num_fetched = 0
-    cheesegull_beatmapsets: list[CheesegullBeatmapset] = []
-    page = offset // amount + 1
-    while num_fetched < amount:
-        osu_api_search_response = await osu_api_v2.search_beatmapsets(
-            query=query,
-            mode=mode,
-            category=ranked_status,
-            page=page,
-        )
-        if not osu_api_search_response.beatmapsets:
-            break
-        cheesegull_beatmapsets.extend(
-            [
-                CheesegullBeatmapset.from_osu_api_beatmapset(osu_api_beatmapset)
-                for osu_api_beatmapset in osu_api_search_response.beatmapsets
-            ],
-        )
-        page += 1
-        num_fetched += len(osu_api_search_response.beatmapsets)
-
-    logging.debug(
-        "Serving cheesegull search",
-        extra={
-            "query": query,
-            "page": page,
-            "results_count": len(cheesegull_beatmapsets),
-            "client_ip_address": client_ip_address,
-            "client_user_agent": client_user_agent,
-        },
+    response = await cheesegull_beatmaps.cheesegull_search(
+        query,
+        status,
+        mode,
+        offset,
+        amount,
+        client_ip_address=client_ip_address,
+        client_user_agent=client_user_agent,
     )
-    return JSONResponse(
-        content=[beatmapset.model_dump() for beatmapset in cheesegull_beatmapsets],
-    )
+    if response is None:
+        return Response(status_code=404)
+
+    return JSONResponse(content=[beatmap.model_dump() for beatmap in response])

--- a/app/api/public/cheesegull.py
+++ b/app/api/public/cheesegull.py
@@ -8,8 +8,10 @@ from fastapi import APIRouter
 from fastapi import Header
 from fastapi import Query
 from fastapi import Response
+
 from app.api.responses import JSONResponse
-from app.common_models import CheesegullRankedStatus, GameMode
+from app.common_models import CheesegullRankedStatus
+from app.common_models import GameMode
 from app.usecases import cheesegull_beatmaps
 
 router = APIRouter(tags=["(Public) Cheesegull API"])

--- a/app/common_models.py
+++ b/app/common_models.py
@@ -1,4 +1,7 @@
+from datetime import datetime
 from enum import IntEnum
+
+from pydantic import BaseModel
 
 
 class RankedStatus(IntEnum):
@@ -58,3 +61,49 @@ class GameMode(IntEnum):
     TAIKO = 1
     FRUITS = 2
     MANIA = 3
+
+
+class CheesegullRankedStatus(IntEnum):
+    # This is a limited subset of the osu! api ranked status
+    PENDING = 0
+    RANKED = 1
+    APPROVED = 2
+    QUALIFIED = 3
+    LOVED = 4
+
+
+class CheesegullBeatmap(BaseModel):
+    BeatmapID: int
+    ParentSetID: int
+    DiffName: str
+    FileMD5: str
+    Mode: int
+    BPM: float
+    AR: float
+    OD: float
+    CS: float
+    HP: float
+    TotalLength: int
+    HitLength: int
+    Playcount: int
+    Passcount: int
+    MaxCombo: int
+    DifficultyRating: float
+
+
+class CheesegullBeatmapset(BaseModel):
+    SetID: int
+    ChildrenBeatmaps: list[CheesegullBeatmap]
+    RankedStatus: int
+    ApprovedDate: datetime
+    LastUpdate: datetime
+    LastChecked: datetime
+    Artist: str
+    Title: str
+    Creator: str
+    Source: str
+    Tags: str
+    HasVideo: bool
+    Genre: int | None
+    Language: int | None
+    Favourites: int

--- a/app/oauth.py
+++ b/app/oauth.py
@@ -63,7 +63,12 @@ class AsyncOAuth(httpx.Auth):
         if client_credentials.access_token is None:
             refresh_response = yield self.build_refresh_request(client_credentials)
             await refresh_response.aread()
-            client_credentials.access_token = refresh_response.json()["access_token"]
+            refresh_response_data = refresh_response.json()
+            if "access_token" not in refresh_response_data:
+                logging.warning(
+                    "Failed to get access token", extra=refresh_response_data
+                )
+            client_credentials.access_token = refresh_response_data["access_token"]
 
         request.headers["Authorization"] = f"Bearer {client_credentials.access_token}"
         response = yield request
@@ -71,7 +76,12 @@ class AsyncOAuth(httpx.Auth):
         while response.status_code == 401:
             refresh_response = yield self.build_refresh_request(client_credentials)
             await refresh_response.aread()
-            client_credentials.access_token = refresh_response.json()["access_token"]
+            refresh_response_data = refresh_response.json()
+            if "access_token" not in refresh_response_data:
+                logging.warning(
+                    "Failed to get access token", extra=refresh_response_data
+                )
+            client_credentials.access_token = refresh_response_data["access_token"]
 
             request.headers["Authorization"] = (
                 f"Bearer {client_credentials.access_token}"

--- a/app/oauth.py
+++ b/app/oauth.py
@@ -66,7 +66,7 @@ class AsyncOAuth(httpx.Auth):
             refresh_response_data = refresh_response.json()
             if "access_token" not in refresh_response_data:
                 logging.warning(
-                    "Failed to get access token", extra=refresh_response_data
+                    "Failed to get access token", extra=refresh_response_data,
                 )
             client_credentials.access_token = refresh_response_data["access_token"]
 
@@ -79,7 +79,7 @@ class AsyncOAuth(httpx.Auth):
             refresh_response_data = refresh_response.json()
             if "access_token" not in refresh_response_data:
                 logging.warning(
-                    "Failed to get access token", extra=refresh_response_data
+                    "Failed to get access token", extra=refresh_response_data,
                 )
             client_credentials.access_token = refresh_response_data["access_token"]
 

--- a/app/oauth.py
+++ b/app/oauth.py
@@ -66,8 +66,8 @@ class AsyncOAuth(httpx.Auth):
             refresh_response_data = refresh_response.json()
             if "access_token" not in refresh_response_data:
                 logging.warning(
-                    "Failed to get access token",
-                    extra={"data": refresh_response_data},
+                    "Failed to get oauth access token",
+                    extra={"response_data": refresh_response_data},
                 )
             client_credentials.access_token = refresh_response_data["access_token"]
 
@@ -80,8 +80,8 @@ class AsyncOAuth(httpx.Auth):
             refresh_response_data = refresh_response.json()
             if "access_token" not in refresh_response_data:
                 logging.warning(
-                    "Failed to get access token",
-                    extra={"data": refresh_response_data},
+                    "Failed to get oauth access token",
+                    extra={"response_data": refresh_response_data},
                 )
             client_credentials.access_token = refresh_response_data["access_token"]
 

--- a/app/oauth.py
+++ b/app/oauth.py
@@ -66,7 +66,7 @@ class AsyncOAuth(httpx.Auth):
             refresh_response_data = refresh_response.json()
             if "access_token" not in refresh_response_data:
                 logging.warning(
-                    "Failed to get access token", extra=refresh_response_data,
+                    "Failed to get access token", extra={"data": refresh_response_data},
                 )
             client_credentials.access_token = refresh_response_data["access_token"]
 
@@ -79,7 +79,7 @@ class AsyncOAuth(httpx.Auth):
             refresh_response_data = refresh_response.json()
             if "access_token" not in refresh_response_data:
                 logging.warning(
-                    "Failed to get access token", extra=refresh_response_data,
+                    "Failed to get access token", extra={"data": refresh_response_data},
                 )
             client_credentials.access_token = refresh_response_data["access_token"]
 

--- a/app/oauth.py
+++ b/app/oauth.py
@@ -66,7 +66,8 @@ class AsyncOAuth(httpx.Auth):
             refresh_response_data = refresh_response.json()
             if "access_token" not in refresh_response_data:
                 logging.warning(
-                    "Failed to get access token", extra={"data": refresh_response_data},
+                    "Failed to get access token",
+                    extra={"data": refresh_response_data},
                 )
             client_credentials.access_token = refresh_response_data["access_token"]
 
@@ -79,7 +80,8 @@ class AsyncOAuth(httpx.Auth):
             refresh_response_data = refresh_response.json()
             if "access_token" not in refresh_response_data:
                 logging.warning(
-                    "Failed to get access token", extra={"data": refresh_response_data},
+                    "Failed to get access token",
+                    extra={"data": refresh_response_data},
                 )
             client_credentials.access_token = refresh_response_data["access_token"]
 

--- a/app/usecases/akatsuki_beatmaps.py
+++ b/app/usecases/akatsuki_beatmaps.py
@@ -156,10 +156,19 @@ async def fetch_one_by_id(beatmap_id: int) -> AkatsukiBeatmap | None:
         beatmap = await akatsuki_beatmaps.create_or_replace(new_beatmap)
 
     elif beatmap.deserves_update:
-        beatmap = await _update_from_osu_api(beatmap)
-        if beatmap is None:
-            # (we may have deleted the map during the update)
-            return None
+        try:
+            beatmap = await _update_from_osu_api(beatmap)
+            if beatmap is None:
+                # (we may have deleted the map during the update)
+                return None
+        except Exception:
+            logging.warning(
+                "Failed to update beatmap requested by id (using old beatmap for now)",
+                extra={
+                    "beatmap": beatmap.model_dump() if beatmap else None,
+                    "beatmap_id": beatmap_id,
+                },
+            )
 
     return beatmap
 
@@ -177,9 +186,18 @@ async def fetch_one_by_md5(beatmap_md5: str) -> AkatsukiBeatmap | None:
         beatmap = await akatsuki_beatmaps.create_or_replace(new_beatmap)
 
     elif beatmap.deserves_update:
-        beatmap = await _update_from_osu_api(beatmap)
-        if beatmap is None:
-            # (we may have deleted the map during the update)
-            return None
+        try:
+            beatmap = await _update_from_osu_api(beatmap)
+            if beatmap is None:
+                # (we may have deleted the map during the update)
+                return None
+        except Exception:
+            logging.warning(
+                "Failed to update beatmap requested by md5 (using old beatmap for now)",
+                extra={
+                    "beatmap": beatmap.model_dump() if beatmap else None,
+                    "beatmap_md5": beatmap_md5,
+                },
+            )
 
     return beatmap

--- a/app/usecases/cheesegull_beatmaps.py
+++ b/app/usecases/cheesegull_beatmaps.py
@@ -88,8 +88,10 @@ async def fetch_one_cheesegull_beatmap(
             if osu_api_beatmap is None:
                 return None
 
-            cheesegull_beatmap = cheesegull_beatmap_from_osu_api_beatmap(
-                osu_api_beatmap,
+            cheesegull_beatmap: CheesegullBeatmap | None = (
+                cheesegull_beatmap_from_osu_api_beatmap(
+                    osu_api_beatmap,
+                )
             )
         except Exception:
             # Fallback to mirror
@@ -131,8 +133,10 @@ async def fetch_one_cheesegull_beatmapset(
             osu_api_beatmapset = await osu_api_v2.get_beatmapset(beatmapset_id)
             if osu_api_beatmapset is None:
                 return None
-            cheesegull_beatmapset = cheesegull_beatmapset_from_osu_api_beatmapset(
-                osu_api_beatmapset,
+            cheesegull_beatmapset: CheesegullBeatmapset | None = (
+                cheesegull_beatmapset_from_osu_api_beatmapset(
+                    osu_api_beatmapset,
+                )
             )
         except Exception:
             # Fallback to mirror

--- a/app/usecases/cheesegull_beatmaps.py
+++ b/app/usecases/cheesegull_beatmaps.py
@@ -1,0 +1,233 @@
+from datetime import datetime
+import logging
+from app.adapters import osu_mirrors
+from app.adapters.osu_api_v2 import api as osu_api_v2
+from app.adapters.osu_api_v2.models import BeatmapExtended
+from app.adapters.osu_api_v2.models import BeatmapsetExtended
+from app.adapters.osu_api_v2.models import Category
+from app.api.responses import JSONResponse
+from app.common_models import (
+    CheesegullBeatmap,
+    CheesegullBeatmapset,
+    CheesegullRankedStatus,
+    GameMode,
+)
+from app.common_models import RankedStatus
+
+
+def cheesegull_beatmap_from_osu_api_beatmap(
+    beatmap: BeatmapExtended,
+) -> "CheesegullBeatmap":
+    return CheesegullBeatmap(
+        BeatmapID=beatmap.id,
+        ParentSetID=beatmap.beatmapset_id,
+        DiffName=beatmap.version,
+        FileMD5=beatmap.checksum or "",
+        Mode=beatmap.mode_int,
+        BPM=beatmap.bpm or 0,
+        AR=beatmap.ar,
+        OD=beatmap.accuracy,
+        CS=beatmap.cs,
+        HP=beatmap.drain,
+        TotalLength=beatmap.total_length,
+        HitLength=beatmap.total_length,
+        Playcount=beatmap.playcount,
+        Passcount=beatmap.passcount,
+        MaxCombo=beatmap.max_combo or 0,
+        DifficultyRating=beatmap.difficulty_rating,
+    )
+
+
+def cheesegull_beatmapset_from_osu_api_beatmapset(
+    osu_api_beatmapset: BeatmapsetExtended,
+) -> "CheesegullBeatmapset":
+    children_beatmaps: list[CheesegullBeatmap] = []
+    for osu_api_beatmap in osu_api_beatmapset.beatmaps or []:
+        if not isinstance(osu_api_beatmap, BeatmapExtended):
+            raise ValueError("beatmapset.beatmaps is not a list of BeatmapExtended")
+        cheesegull_beatmap = cheesegull_beatmap_from_osu_api_beatmap(osu_api_beatmap)
+        children_beatmaps.append(cheesegull_beatmap)
+
+    return CheesegullBeatmapset(
+        SetID=osu_api_beatmapset.id,
+        ChildrenBeatmaps=children_beatmaps,
+        RankedStatus=osu_api_beatmapset.ranked,
+        ApprovedDate=osu_api_beatmapset.ranked_date or datetime.min,
+        LastUpdate=(osu_api_beatmapset.ranked_date or osu_api_beatmapset.last_updated),
+        LastChecked=datetime.now(),  # TODO: Implement this
+        Artist=osu_api_beatmapset.artist,
+        Title=osu_api_beatmapset.title,
+        Creator=osu_api_beatmapset.creator,
+        Source=osu_api_beatmapset.source,
+        Tags=osu_api_beatmapset.tags,
+        HasVideo=osu_api_beatmapset.video,
+        Genre=osu_api_beatmapset.genre.id if osu_api_beatmapset.genre else None,
+        Language=(
+            osu_api_beatmapset.language.id if osu_api_beatmapset.language else None
+        ),
+        Favourites=osu_api_beatmapset.favourite_count,
+    )
+
+
+def get_osu_api_v2_search_ranked_status(
+    cheesegull_status: CheesegullRankedStatus,
+) -> Category | None:
+    ranked_status = RankedStatus.from_osu_api(cheesegull_status)
+    search_ranked_status = Category.from_ranked_status(ranked_status)
+    return search_ranked_status
+
+
+async def fetch_one_cheesegull_beatmap(
+    beatmap_id: int,
+    *,
+    client_ip_address: str | None,
+    client_user_agent: str | None,
+) -> CheesegullBeatmap | None:
+    try:
+        try:
+            osu_api_beatmap = await osu_api_v2.get_beatmap(beatmap_id)
+            if osu_api_beatmap is None:
+                return None
+
+            cheesegull_beatmap = cheesegull_beatmap_from_osu_api_beatmap(
+                osu_api_beatmap
+            )
+        except Exception:
+            # Fallback to mirror
+            cheesegull_beatmap = await osu_mirrors.fetch_one_cheesegull_beatmap(
+                beatmap_id
+            )
+            if cheesegull_beatmap is None:
+                return None
+
+        logging.debug(
+            "Serving cheesegull beatmap",
+            extra={
+                "beatmap_id": beatmap_id,
+                "client_ip_address": client_ip_address,
+                "client_user_agent": client_user_agent,
+            },
+        )
+        return cheesegull_beatmap
+    except Exception:
+        logging.exception(
+            "Failed to fetch cheesegull beatmap",
+            extra={
+                "beatmap_id": beatmap_id,
+                "client_ip_address": client_ip_address,
+                "client_user_agent": client_user_agent,
+            },
+        )
+        return None
+
+
+async def fetch_one_cheesegull_beatmapset(
+    beatmapset_id: int,
+    *,
+    client_ip_address: str | None,
+    client_user_agent: str | None,
+) -> CheesegullBeatmapset | None:
+    try:
+        try:
+            osu_api_beatmapset = await osu_api_v2.get_beatmapset(beatmapset_id)
+            if osu_api_beatmapset is None:
+                return None
+            cheesegull_beatmapset = cheesegull_beatmapset_from_osu_api_beatmapset(
+                osu_api_beatmapset,
+            )
+        except Exception:
+            # Fallback to mirror
+            cheesegull_beatmapset = await osu_mirrors.fetch_one_cheesegull_beatmapset(
+                beatmapset_id
+            )
+            if cheesegull_beatmapset is None:
+                return None
+
+        logging.debug(
+            "Serving cheesegull beatmapset",
+            extra={
+                "beatmapset_id": beatmapset_id,
+                "client_ip_address": client_ip_address,
+                "client_user_agent": client_user_agent,
+            },
+        )
+        return cheesegull_beatmapset
+    except Exception:
+        logging.exception(
+            "Failed to fetch cheesegull beatmapset",
+            extra={
+                "beatmapset_id": beatmapset_id,
+                "client_ip_address": client_ip_address,
+                "client_user_agent": client_user_agent,
+            },
+        )
+        return None
+
+
+async def cheesegull_search(
+    query: str,
+    status: CheesegullRankedStatus | None,
+    mode: GameMode | None,
+    offset: int,
+    amount: int,
+    client_ip_address: str | None,
+    client_user_agent: str | None,
+) -> list[CheesegullBeatmapset] | None:
+    try:
+        if status is not None:
+            ranked_status = get_osu_api_v2_search_ranked_status(status)
+            if ranked_status is None:
+                logging.warning(
+                    "Invalid cheesegull search status",
+                    extra={
+                        "search_status": status,
+                        "client_ip_address": client_ip_address,
+                        "client_user_agent": client_user_agent,
+                    },
+                )
+                return None
+        else:
+            ranked_status = None
+
+        num_fetched = 0
+        cheesegull_beatmapsets: list[CheesegullBeatmapset] = []
+        page = offset // amount + 1
+        while num_fetched < amount:
+            osu_api_search_response = await osu_api_v2.search_beatmapsets(
+                query=query,
+                mode=mode,
+                category=ranked_status,
+                page=page,
+            )
+            if not osu_api_search_response.beatmapsets:
+                break
+            cheesegull_beatmapsets.extend(
+                [
+                    cheesegull_beatmapset_from_osu_api_beatmapset(osu_api_beatmapset)
+                    for osu_api_beatmapset in osu_api_search_response.beatmapsets
+                ],
+            )
+            page += 1
+            num_fetched += len(osu_api_search_response.beatmapsets)
+
+        logging.debug(
+            "Serving cheesegull search",
+            extra={
+                "query": query,
+                "page": page,
+                "results_count": len(cheesegull_beatmapsets),
+                "client_ip_address": client_ip_address,
+                "client_user_agent": client_user_agent,
+            },
+        )
+        return cheesegull_beatmapsets
+    except Exception:
+        logging.exception(
+            "Failed to fetch cheesegull search",
+            extra={
+                "query": query,
+                "client_ip_address": client_ip_address,
+                "client_user_agent": client_user_agent,
+            },
+        )
+        return None

--- a/app/usecases/cheesegull_beatmaps.py
+++ b/app/usecases/cheesegull_beatmaps.py
@@ -1,17 +1,16 @@
-from datetime import datetime
 import logging
+from datetime import datetime
+
 from app.adapters import osu_mirrors
 from app.adapters.osu_api_v2 import api as osu_api_v2
 from app.adapters.osu_api_v2.models import BeatmapExtended
 from app.adapters.osu_api_v2.models import BeatmapsetExtended
 from app.adapters.osu_api_v2.models import Category
 from app.api.responses import JSONResponse
-from app.common_models import (
-    CheesegullBeatmap,
-    CheesegullBeatmapset,
-    CheesegullRankedStatus,
-    GameMode,
-)
+from app.common_models import CheesegullBeatmap
+from app.common_models import CheesegullBeatmapset
+from app.common_models import CheesegullRankedStatus
+from app.common_models import GameMode
 from app.common_models import RankedStatus
 
 
@@ -90,12 +89,12 @@ async def fetch_one_cheesegull_beatmap(
                 return None
 
             cheesegull_beatmap = cheesegull_beatmap_from_osu_api_beatmap(
-                osu_api_beatmap
+                osu_api_beatmap,
             )
         except Exception:
             # Fallback to mirror
             cheesegull_beatmap = await osu_mirrors.fetch_one_cheesegull_beatmap(
-                beatmap_id
+                beatmap_id,
             )
             if cheesegull_beatmap is None:
                 return None
@@ -138,7 +137,7 @@ async def fetch_one_cheesegull_beatmapset(
         except Exception:
             # Fallback to mirror
             cheesegull_beatmapset = await osu_mirrors.fetch_one_cheesegull_beatmapset(
-                beatmapset_id
+                beatmapset_id,
             )
             if cheesegull_beatmapset is None:
                 return None


### PR DESCRIPTION
This gets us a good start:
- Fallback to osu!direct for cheesegull beatmap & beatmapset requests
- Allow beatmap updates to fail, and return the old map when it happens

But it's not everything. We need more failsafes on osu api v1 and v2.