### PR TITLE
Use osu API rate limit headers

### DIFF
--- a/app/adapters/osu_api_backoff.py
+++ b/app/adapters/osu_api_backoff.py
@@ -13,6 +13,9 @@ DEFAULT_FAILURE_COOLDOWN_SECONDS = 10
 DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 60
 DEFAULT_OSU_API_REQUESTS_PER_MINUTE = 600
 DEFAULT_OSU_API_BURST_SIZE = 10
+RATE_LIMIT_LIMIT_HEADER = "X-Ratelimit-Limit"
+RATE_LIMIT_REMAINING_HEADER = "X-Ratelimit-Remaining"
+RATE_LIMIT_RESET_HEADER = "X-Ratelimit-Reset"
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +157,7 @@ class OsuApiBackoff:
         endpoint: str,
         cooldown_seconds: float | None = None,
         force_open: bool = False,
+        log_extra: dict[str, object] | None = None,
     ) -> None:
         cooldown_seconds = cooldown_seconds or self._failure_cooldown_seconds
 
@@ -176,16 +180,20 @@ class OsuApiBackoff:
             self._cooldown_seconds = cooldown_seconds
             self._probe_in_flight = False
 
+        extra: dict[str, object] = {
+            "upstream": upstream,
+            "endpoint": endpoint,
+            "previous_state": previous_state,
+            "circuit_state": CircuitState.OPEN,
+            "consecutive_failures": self._consecutive_failures,
+            "cooldown_seconds": cooldown_seconds,
+        }
+        if log_extra is not None:
+            extra.update(log_extra)
+
         logger.warning(
             "Opened osu! API circuit",
-            extra={
-                "upstream": upstream,
-                "endpoint": endpoint,
-                "previous_state": previous_state,
-                "circuit_state": CircuitState.OPEN,
-                "consecutive_failures": self._consecutive_failures,
-                "cooldown_seconds": cooldown_seconds,
-            },
+            extra=extra,
         )
 
     def apply_if_rate_limited(
@@ -207,6 +215,37 @@ class OsuApiBackoff:
         )
         raise OsuApiBackoffError(
             f"{upstream} returned {response.status_code}; backing off",
+        )
+
+    def record_rate_limit_headers(
+        self,
+        response: httpx.Response,
+        *,
+        upstream: str,
+        endpoint: str,
+    ) -> None:
+        remaining = _get_int_header(response, RATE_LIMIT_REMAINING_HEADER)
+        if remaining is None or remaining > 0:
+            return
+
+        limit = _get_int_header(response, RATE_LIMIT_LIMIT_HEADER)
+        cooldown_seconds = _get_rate_limit_reset_cooldown_seconds(response)
+        if cooldown_seconds is None:
+            cooldown_seconds = DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
+
+        self.record_failure(
+            upstream=upstream,
+            endpoint=endpoint,
+            cooldown_seconds=cooldown_seconds,
+            force_open=True,
+            log_extra={
+                "reason": "rate_limit_headers_exhausted",
+                "rate_limit": {
+                    "limit": limit,
+                    "remaining": remaining,
+                    "reset": response.headers.get(RATE_LIMIT_RESET_HEADER),
+                },
+            },
         )
 
     def _evaluate_state(self) -> CircuitState:
@@ -254,6 +293,10 @@ class OsuApiBackoff:
 def _get_rate_limit_cooldown_seconds(response: httpx.Response) -> int:
     retry_after = response.headers.get("Retry-After")
     if retry_after is None:
+        reset_cooldown_seconds = _get_rate_limit_reset_cooldown_seconds(response)
+        if reset_cooldown_seconds is not None:
+            return reset_cooldown_seconds
+
         return DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
 
     try:
@@ -264,6 +307,30 @@ def _get_rate_limit_cooldown_seconds(response: httpx.Response) -> int:
             return DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
 
         return max(1, int((retry_at - datetime.now(timezone.utc)).total_seconds()))
+
+
+def _get_rate_limit_reset_cooldown_seconds(response: httpx.Response) -> int | None:
+    reset = response.headers.get(RATE_LIMIT_RESET_HEADER)
+    if reset is None:
+        return None
+
+    try:
+        reset_at = int(reset)
+    except ValueError:
+        return None
+
+    return max(1, reset_at - int(time.time()))
+
+
+def _get_int_header(response: httpx.Response, header: str) -> int | None:
+    value = response.headers.get(header)
+    if value is None:
+        return None
+
+    try:
+        return int(value)
+    except ValueError:
+        return None
 
 
 def _parse_retry_after_datetime(retry_after: str) -> datetime | None:

--- a/app/adapters/osu_api_v2/api.py
+++ b/app/adapters/osu_api_v2/api.py
@@ -52,6 +52,11 @@ async def get_beatmap(beatmap_id: int) -> BeatmapExtended | None:
             upstream="osu! API v2",
             endpoint=endpoint,
         )
+        osu_api_v2_backoff.record_rate_limit_headers(
+            response,
+            upstream="osu! API v2",
+            endpoint=endpoint,
+        )
         if response.status_code in (404, 451):
             osu_api_v2_backoff.record_success(
                 upstream="osu! API v2",
@@ -85,6 +90,11 @@ async def get_beatmapset(beatmapset_id: int) -> BeatmapsetExtended | None:
     try:
         response = await osu_api_v2_http_client.get(f"beatmapsets/{beatmapset_id}")
         osu_api_v2_backoff.apply_if_rate_limited(
+            response,
+            upstream="osu! API v2",
+            endpoint=endpoint,
+        )
+        osu_api_v2_backoff.record_rate_limit_headers(
             response,
             upstream="osu! API v2",
             endpoint=endpoint,
@@ -154,6 +164,11 @@ async def search_beatmapsets(
             },
         )
         osu_api_v2_backoff.apply_if_rate_limited(
+            response,
+            upstream="osu! API v2",
+            endpoint=endpoint,
+        )
+        osu_api_v2_backoff.record_rate_limit_headers(
             response,
             upstream="osu! API v2",
             endpoint=endpoint,

--- a/app/oauth.py
+++ b/app/oauth.py
@@ -73,6 +73,11 @@ class AsyncOAuth(httpx.Auth):
                     upstream="osu! API v2",
                     endpoint="oauth/token",
                 )
+                self.backoff.record_rate_limit_headers(
+                    refresh_response,
+                    upstream="osu! API v2",
+                    endpoint="oauth/token",
+                )
             refresh_response_data = refresh_response.json()
             if "access_token" not in refresh_response_data:
                 logging.warning(
@@ -94,6 +99,11 @@ class AsyncOAuth(httpx.Auth):
             await refresh_response.aread()
             if self.backoff is not None:
                 self.backoff.apply_if_rate_limited(
+                    refresh_response,
+                    upstream="osu! API v2",
+                    endpoint="oauth/token",
+                )
+                self.backoff.record_rate_limit_headers(
                     refresh_response,
                     upstream="osu! API v2",
                     endpoint="oauth/token",

--- a/tests/test_osu_api_backoff.py
+++ b/tests/test_osu_api_backoff.py
@@ -100,6 +100,87 @@ class OsuApiBackoffTestCase(unittest.TestCase):
             mock_time.monotonic.return_value = started_at + 61
             self.assertEqual(backoff.state, CircuitState.HALF_OPEN)
 
+    def test_zero_remaining_rate_limit_header_opens_circuit(self) -> None:
+        backoff = OsuApiBackoff()
+
+        backoff.record_rate_limit_headers(
+            httpx.Response(
+                200,
+                headers={
+                    "X-Ratelimit-Limit": "1200",
+                    "X-Ratelimit-Remaining": "0",
+                },
+            ),
+            upstream="osu! API v2",
+            endpoint="beatmaps",
+        )
+
+        self.assertEqual(backoff.state, CircuitState.OPEN)
+        with self.assertRaises(OsuApiBackoffError):
+            backoff.raise_if_unavailable(upstream="osu! API v2")
+
+    def test_positive_remaining_rate_limit_header_does_not_open_circuit(self) -> None:
+        backoff = OsuApiBackoff()
+
+        backoff.record_rate_limit_headers(
+            httpx.Response(
+                200,
+                headers={
+                    "X-Ratelimit-Limit": "1200",
+                    "X-Ratelimit-Remaining": "1",
+                },
+            ),
+            upstream="osu! API v2",
+            endpoint="beatmaps",
+        )
+
+        self.assertEqual(backoff.state, CircuitState.CLOSED)
+
+    def test_rate_limit_reset_header_controls_cooldown(self) -> None:
+        backoff = OsuApiBackoff()
+        started_at = time.monotonic()
+
+        with patch("app.adapters.osu_api_backoff.time") as mock_time:
+            mock_time.monotonic.return_value = started_at
+            mock_time.time.return_value = 1000
+            backoff.record_rate_limit_headers(
+                httpx.Response(
+                    200,
+                    headers={
+                        "X-Ratelimit-Remaining": "0",
+                        "X-Ratelimit-Reset": "1030",
+                    },
+                ),
+                upstream="osu! API v2",
+                endpoint="beatmaps",
+            )
+
+            mock_time.monotonic.return_value = started_at + 29
+            self.assertEqual(backoff.state, CircuitState.OPEN)
+
+            mock_time.monotonic.return_value = started_at + 30
+            self.assertEqual(backoff.state, CircuitState.HALF_OPEN)
+
+    def test_rate_limit_response_uses_reset_header_without_retry_after(self) -> None:
+        backoff = OsuApiBackoff()
+        started_at = time.monotonic()
+
+        with patch("app.adapters.osu_api_backoff.time") as mock_time:
+            mock_time.monotonic.return_value = started_at
+            mock_time.time.return_value = 1000
+            with self.assertRaises(OsuApiBackoffError):
+                backoff.apply_if_rate_limited(
+                    httpx.Response(429, headers={"X-Ratelimit-Reset": "1030"}),
+                    upstream="osu! API v2",
+                    endpoint="beatmaps",
+                )
+
+            mock_time.monotonic.return_value = started_at + 29
+            self.assertEqual(backoff.state, CircuitState.OPEN)
+
+            mock_time.monotonic.return_value = started_at + 30
+            self.assertEqual(backoff.state, CircuitState.HALF_OPEN)
+
     def test_in_flight_success_does_not_close_open_circuit(self) -> None:
         backoff = OsuApiBackoff()
 


### PR DESCRIPTION
## Summary
- consume osu API `X-Ratelimit-Remaining` headers in the shared backoff path
- open the v2 circuit after a successful response reports zero remaining quota, so the next request fails locally instead of becoming a 429
- use `X-Ratelimit-Reset` as a cooldown fallback when `Retry-After` is absent
- wire the header feedback into v2 beatmap/beatmapset/search responses and OAuth token refreshes

## Upstream context
- osu-web's API route group uses its custom `ThrottleRequests::getApiThrottle()` middleware for `/api/v2`: https://github.com/ppy/osu-web/blob/master/routes/web.php#L442-L443
- osu-web's throttle middleware adds the standard throttle headers after requests: https://github.com/ppy/osu-web/blob/master/app/Http/Middleware/ThrottleRequests.php#L24-L45
- osu-web tests assert `X-Ratelimit-Limit` and `X-Ratelimit-Remaining`: https://github.com/ppy/osu-web/blob/master/tests/Middleware/ThrottleRequestsTest.php#L24-L39

## Tests
- `python3 -m unittest discover tests`
- `python3 -m py_compile app/adapters/osu_api_backoff.py app/adapters/osu_api_v2/api.py app/oauth.py tests/test_osu_api_backoff.py`
- `python3 -m mypy app/adapters/osu_api_backoff.py app/adapters/osu_api_v2/api.py app/oauth.py`