### PR TITLE
Fix public Akatsuki beatmaps route

### DIFF
--- a/app/api/public/akatsuki.py
+++ b/app/api/public/akatsuki.py
@@ -8,6 +8,8 @@ from fastapi import Query
 from fastapi import Response
 
 from app.api.responses import JSONResponse
+from app.repositories.akatsuki_beatmaps import AkatsukiBeatmapSortBy
+from app.repositories.akatsuki_beatmaps import SortOrder
 from app.usecases import akatsuki_beatmaps
 
 router = APIRouter(tags=["(Public) Akatsuki Beatmaps"])
@@ -18,11 +20,15 @@ async def fetch_many_beatmaps(
     only_custom_ranked: bool = False,
     page: int = Query(1, ge=1),
     limit: int = Query(50, ge=1, le=100),
+    sort_by: AkatsukiBeatmapSortBy = AkatsukiBeatmapSortBy.LATEST_UPDATE,
+    sort_order: SortOrder = SortOrder.DESC,
 ) -> Response:
     beatmaps = await akatsuki_beatmaps.fetch_many(
         only_custom_ranked=only_custom_ranked,
         offset=(page - 1) * limit,
         limit=limit,
+        sort_by=sort_by,
+        sort_order=sort_order,
     )
     return JSONResponse(
         content=[beatmap.model_dump() for beatmap in beatmaps],

--- a/app/api/public/akatsuki.py
+++ b/app/api/public/akatsuki.py
@@ -13,7 +13,7 @@ from app.usecases import akatsuki_beatmaps
 router = APIRouter(tags=["(Public) Akatsuki Beatmaps"])
 
 
-@router.get("/api/akatsuki/v1/beatmaps")
+@router.get("/public/api/akatsuki/v1/beatmaps")
 async def fetch_many_beatmaps(
     only_custom_ranked: bool = False,
     page: int = Query(1, ge=1),

--- a/app/repositories/akatsuki_beatmaps.py
+++ b/app/repositories/akatsuki_beatmaps.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from enum import Enum
 
 from databases.interfaces import Record
 from pydantic import BaseModel
@@ -7,6 +8,24 @@ from pydantic import BaseModel
 from app import state
 from app.common_models import GameMode
 from app.common_models import RankedStatus
+
+
+class AkatsukiBeatmapSortBy(str, Enum):
+    LATEST_UPDATE = "latest_update"
+    BEATMAP_ID = "beatmap_id"
+    BEATMAPSET_ID = "beatmapset_id"
+    SONG_NAME = "song_name"
+    RANKED = "ranked"
+    BANCHO_RANKED_STATUS = "bancho_ranked_status"
+    MODE = "mode"
+    PLAYCOUNT = "playcount"
+    PASSCOUNT = "passcount"
+    RATING = "rating"
+
+
+class SortOrder(str, Enum):
+    ASC = "asc"
+    DESC = "desc"
 
 
 class AkatsukiBeatmap(BaseModel):
@@ -97,6 +116,26 @@ def _parse_akatsuki_beatmap_record(rec: Record) -> AkatsukiBeatmap:
     )
 
 
+SORT_COLUMNS = {
+    AkatsukiBeatmapSortBy.LATEST_UPDATE: "latest_update",
+    AkatsukiBeatmapSortBy.BEATMAP_ID: "beatmap_id",
+    AkatsukiBeatmapSortBy.BEATMAPSET_ID: "beatmapset_id",
+    AkatsukiBeatmapSortBy.SONG_NAME: "song_name",
+    AkatsukiBeatmapSortBy.RANKED: "ranked",
+    AkatsukiBeatmapSortBy.BANCHO_RANKED_STATUS: "bancho_ranked_status",
+    AkatsukiBeatmapSortBy.MODE: "mode",
+    AkatsukiBeatmapSortBy.PLAYCOUNT: "playcount",
+    AkatsukiBeatmapSortBy.PASSCOUNT: "passcount",
+    AkatsukiBeatmapSortBy.RATING: "rating",
+}
+
+
+SORT_ORDERS = {
+    SortOrder.ASC: "ASC",
+    SortOrder.DESC: "DESC",
+}
+
+
 async def fetch_one_by_md5(beatmap_md5: str, /) -> AkatsukiBeatmap | None:
     query = """\
         SELECT * FROM beatmaps WHERE beatmap_md5 = :beatmap_md5
@@ -122,6 +161,8 @@ async def fetch_many(
     only_custom_ranked: bool = False,
     offset: int = 0,
     limit: int = 50,
+    sort_by: AkatsukiBeatmapSortBy = AkatsukiBeatmapSortBy.LATEST_UPDATE,
+    sort_order: SortOrder = SortOrder.DESC,
 ) -> list[AkatsukiBeatmap]:
     conditions: list[str] = []
     values: dict[str, object] = {"offset": offset, "limit": limit}
@@ -135,10 +176,15 @@ async def fetch_many(
         )
 
     where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    sort_column = SORT_COLUMNS[sort_by]
+    sort_direction = SORT_ORDERS[sort_order]
+    tie_breaker = (
+        "" if sort_by is AkatsukiBeatmapSortBy.BEATMAP_ID else ", beatmap_id ASC"
+    )
     query = f"""\
         SELECT * FROM beatmaps
         {where_clause}
-        ORDER BY latest_update DESC
+        ORDER BY {sort_column} {sort_direction}{tie_breaker}
         LIMIT :limit OFFSET :offset
     """
     recs = await state.database.fetch_all(query, values)

--- a/app/usecases/akatsuki_beatmaps.py
+++ b/app/usecases/akatsuki_beatmaps.py
@@ -8,6 +8,8 @@ from app.adapters.osu_api_backoff import OsuApiBackoffError
 from app.common_models import RankedStatus
 from app.repositories import akatsuki_beatmaps
 from app.repositories.akatsuki_beatmaps import AkatsukiBeatmap
+from app.repositories.akatsuki_beatmaps import AkatsukiBeatmapSortBy
+from app.repositories.akatsuki_beatmaps import SortOrder
 
 IGNORED_BEATMAP_CHARS = dict.fromkeys(map(ord, r':\/*<>?"|'), None)
 FROZEN_STATUSES = {RankedStatus.RANKED, RankedStatus.APPROVED, RankedStatus.LOVED}
@@ -227,9 +229,13 @@ async def fetch_many(
     only_custom_ranked: bool = False,
     offset: int = 0,
     limit: int = 50,
+    sort_by: AkatsukiBeatmapSortBy = AkatsukiBeatmapSortBy.LATEST_UPDATE,
+    sort_order: SortOrder = SortOrder.DESC,
 ) -> list[AkatsukiBeatmap]:
     return await akatsuki_beatmaps.fetch_many(
         only_custom_ranked=only_custom_ranked,
         offset=offset,
         limit=limit,
+        sort_by=sort_by,
+        sort_order=sort_order,
     )


### PR DESCRIPTION
The production nginx config rewrites public beatmaps.akatsuki.gg requests from /<path> to /public/<path> before proxying to beatmaps-service. Register the new Akatsuki beatmaps listing under /public/api/... so the external /api/akatsuki/v1/beatmaps URL resolves correctly.\n\nValidation:\n- ./venv/bin/python -m black app/api/public/akatsuki.py --check\n- ./venv/bin/python -m isort app/api/public/akatsuki.py --check-only --profile black --force-single-line-imports\n- ./venv/bin/python -m mypy app\n- local route smoke test shows /public/api/akatsuki/v1/beatmaps