### PR TITLE
Add public beatmap listing filters

### DIFF
--- a/app/api/public/akatsuki.py
+++ b/app/api/public/akatsuki.py
@@ -8,6 +8,8 @@ from fastapi import Query
 from fastapi import Response
 
 from app.api.responses import JSONResponse
+from app.common_models import GameMode
+from app.common_models import RankedStatus
 from app.repositories.akatsuki_beatmaps import AkatsukiBeatmapSortBy
 from app.repositories.akatsuki_beatmaps import SortOrder
 from app.usecases import akatsuki_beatmaps
@@ -22,6 +24,11 @@ async def fetch_many_beatmaps(
     limit: int = Query(50, ge=1, le=100),
     sort_by: AkatsukiBeatmapSortBy = AkatsukiBeatmapSortBy.LATEST_UPDATE,
     sort_order: SortOrder = SortOrder.DESC,
+    ranked: list[RankedStatus] | None = Query(None),
+    mode: list[GameMode] | None = Query(None),
+    bancho_creator_id: int | None = Query(None, ge=0),
+    bancho_creator_name: str | None = Query(None, min_length=1),
+    rankedby: int | None = Query(None, ge=0),
 ) -> Response:
     beatmaps = await akatsuki_beatmaps.fetch_many(
         only_custom_ranked=only_custom_ranked,
@@ -29,6 +36,11 @@ async def fetch_many_beatmaps(
         limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
+        ranked=ranked,
+        mode=mode,
+        bancho_creator_id=bancho_creator_id,
+        bancho_creator_name=bancho_creator_name,
+        rankedby=rankedby,
     )
     return JSONResponse(
         content=[beatmap.model_dump() for beatmap in beatmaps],

--- a/app/repositories/akatsuki_beatmaps.py
+++ b/app/repositories/akatsuki_beatmaps.py
@@ -124,6 +124,26 @@ SORT_ORDERS = {
 }
 
 
+def _add_int_values_filter(
+    *,
+    conditions: list[str],
+    values: dict[str, object],
+    column_name: str,
+    param_name: str,
+    filter_values: list[int],
+) -> None:
+    if not filter_values:
+        return
+
+    placeholders: list[str] = []
+    for index, filter_value in enumerate(filter_values):
+        placeholder_name = f"{param_name}_{index}"
+        placeholders.append(f":{placeholder_name}")
+        values[placeholder_name] = filter_value
+
+    conditions.append(f"{column_name} IN ({', '.join(placeholders)})")
+
+
 async def fetch_one_by_md5(beatmap_md5: str, /) -> AkatsukiBeatmap | None:
     query = """\
         SELECT * FROM beatmaps WHERE beatmap_md5 = :beatmap_md5
@@ -151,6 +171,11 @@ async def fetch_many(
     limit: int = 50,
     sort_by: AkatsukiBeatmapSortBy = AkatsukiBeatmapSortBy.LATEST_UPDATE,
     sort_order: SortOrder = SortOrder.DESC,
+    ranked: list[RankedStatus] | None = None,
+    mode: list[GameMode] | None = None,
+    bancho_creator_id: int | None = None,
+    bancho_creator_name: str | None = None,
+    rankedby: int | None = None,
 ) -> list[AkatsukiBeatmap]:
     conditions: list[str] = []
     values: dict[str, object] = {"offset": offset, "limit": limit}
@@ -162,6 +187,36 @@ async def fetch_many(
                 "ranked != bancho_ranked_status",
             ],
         )
+
+    if ranked is not None:
+        _add_int_values_filter(
+            conditions=conditions,
+            values=values,
+            column_name="ranked",
+            param_name="ranked",
+            filter_values=[ranked_status.value for ranked_status in ranked],
+        )
+
+    if mode is not None:
+        _add_int_values_filter(
+            conditions=conditions,
+            values=values,
+            column_name="mode",
+            param_name="mode",
+            filter_values=[game_mode.value for game_mode in mode],
+        )
+
+    if bancho_creator_id is not None:
+        conditions.append("bancho_creator_id = :bancho_creator_id")
+        values["bancho_creator_id"] = bancho_creator_id
+
+    if bancho_creator_name is not None:
+        conditions.append("bancho_creator_name = :bancho_creator_name")
+        values["bancho_creator_name"] = bancho_creator_name
+
+    if rankedby is not None:
+        conditions.append("rankedby = :rankedby")
+        values["rankedby"] = rankedby
 
     where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
     sort_column = SORT_COLUMNS[sort_by]

--- a/app/usecases/akatsuki_beatmaps.py
+++ b/app/usecases/akatsuki_beatmaps.py
@@ -5,6 +5,7 @@ from app.adapters import aws_s3
 from app.adapters import discord_webhooks
 from app.adapters import osu_api_v1
 from app.adapters.osu_api_backoff import OsuApiBackoffError
+from app.common_models import GameMode
 from app.common_models import RankedStatus
 from app.repositories import akatsuki_beatmaps
 from app.repositories.akatsuki_beatmaps import AkatsukiBeatmap
@@ -231,6 +232,11 @@ async def fetch_many(
     limit: int = 50,
     sort_by: AkatsukiBeatmapSortBy = AkatsukiBeatmapSortBy.LATEST_UPDATE,
     sort_order: SortOrder = SortOrder.DESC,
+    ranked: list[RankedStatus] | None = None,
+    mode: list[GameMode] | None = None,
+    bancho_creator_id: int | None = None,
+    bancho_creator_name: str | None = None,
+    rankedby: int | None = None,
 ) -> list[AkatsukiBeatmap]:
     return await akatsuki_beatmaps.fetch_many(
         only_custom_ranked=only_custom_ranked,
@@ -238,4 +244,9 @@ async def fetch_many(
         limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
+        ranked=ranked,
+        mode=mode,
+        bancho_creator_id=bancho_creator_id,
+        bancho_creator_name=bancho_creator_name,
+        rankedby=rankedby,
     )


### PR DESCRIPTION
Add exact-match filters to the public Akatsuki beatmaps listing endpoint.\n\nFilters added:\n- ranked, repeatable enum/int status query param\n- mode, repeatable enum/int query param\n- bancho_creator_id\n- bancho_creator_name\n- rankedby\n\nValidation:\n- ./venv/bin/python -m isort app/api/public/akatsuki.py app/usecases/akatsuki_beatmaps.py app/repositories/akatsuki_beatmaps.py --profile black --force-single-line-imports\n- ./venv/bin/python -m black app/api/public/akatsuki.py app/usecases/akatsuki_beatmaps.py app/repositories/akatsuki_beatmaps.py\n- ./venv/bin/python -m mypy app\n- local route smoke test includes the new query params